### PR TITLE
Fix: Correct Procfile syntax

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -w 4 -b 0.0.0.0:$PORT 'StudentsWebApp.app:app'
+web: gunicorn -w 4 -b 0.0.0.0:$PORT StudentsWebApp.app:app


### PR DESCRIPTION
The deployment was failing with an EOF error, likely due to the single quotes in the gunicorn command in the Procfile.

This commit removes the single quotes around the application path in the Procfile to resolve the syntax issue.