### PR TITLE
Fix: Add name to db.Enum for PostgreSQL compatibility

### DIFF
--- a/StudentsWebApp/app.py
+++ b/StudentsWebApp/app.py
@@ -5,6 +5,7 @@ from flask import jsonify
 import wikipedia
 from transformers import pipeline
 import re
+import enum
 import random
 from dateutil.parser import parse
 import math
@@ -139,11 +140,15 @@ class Resource(db.Model):
     course = db.Column(db.String(100))
     cohort = db.Column(db.String(10))
 
+
+class RoleEnum(enum.Enum):
+    GRADUATE = 'graduate'
+    GUEST = 'guest'
 class GraduationRegistration(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     student_email = db.Column(db.String(100), nullable=False)
     full_name = db.Column(db.String(100), nullable=False)
-    role = db.Column(db.Enum('graduate', 'guest'), nullable=False)
+    role = db.Column(db.Enum(RoleEnum, name="role_enum"), nullable=False)
     date_registered = db.Column(db.DateTime, default=datetime.utcnow)
 
 class GraduationInfo(db.Model):


### PR DESCRIPTION
Modified the `GraduationRegistration` model in `StudentsWebApp/app.py` to use a named Python `enum.Enum` for the `role` column (e.g., `db.Enum(RoleEnum, name="role_enum")`).

This resolves the `sqlalchemy.exc.CompileError: PostgreSQL ENUM type requires a name` that occurred during `db.create_all()` when targeting a PostgreSQL database.